### PR TITLE
Feature/modify cleanup

### DIFF
--- a/src/trigger_rand.js
+++ b/src/trigger_rand.js
@@ -7,13 +7,12 @@ const {
   createMaxObject,
   createMaxObjects,
   connect,
-  getCleanupHandler,
+  cleanup,
   positionMaxObjects,
 } = require('utils');
 
 const constructPatch = () => {
   const ARGS = getArgs();
-  const cleanup = getCleanupHandler();
   cleanup();
   const maxObjects = generateObjects();
   

--- a/src/trigger_rand.js
+++ b/src/trigger_rand.js
@@ -14,6 +14,7 @@ const {
 const constructPatch = () => {
   const ARGS = getArgs();
   const cleanup = getCleanupHandler();
+  cleanup();
   const maxObjects = generateObjects();
   
   connectMaxObjects(maxObjects);
@@ -23,7 +24,6 @@ const constructPatch = () => {
     posOffset: 100,
     boxOffset: 80
   });
-  cleanup();
 
   function generateObjects () {
     const maxObjects = {

--- a/src/util_organization.js
+++ b/src/util_organization.js
@@ -1,11 +1,15 @@
-const getCleanupHandler = () => {
+const cleanup = () => {
   const lastObj = getLastMaxObj();
   const maxObjList = getMaxObjList(lastObj);
 
-  const cleanup = () => {
-    maxObjList.forEach(maxObj => patcher.remove(maxObj));
-  }
-  return cleanup;
+  // const cleanup = () => {
+  //   maxObjList.forEach(maxObj => patcher.remove(maxObj));
+  // }
+  // return cleanup;
+
+  (() => {
+      maxObjList.forEach(maxObj => patcher.remove(maxObj));
+  })();
 };
 
 const alignCables = () => post("TODO alignCables");
@@ -32,5 +36,5 @@ function getLastMaxObj () {
   return currentObj;
 }
 
-exports.getCleanupHandler = getCleanupHandler;
+exports.cleanup = cleanup;
 exports.alignCables = alignCables;

--- a/src/util_organization.js
+++ b/src/util_organization.js
@@ -2,11 +2,6 @@ const cleanup = () => {
   const lastObj = getLastMaxObj();
   const maxObjList = getMaxObjList(lastObj);
 
-  // const cleanup = () => {
-  //   maxObjList.forEach(maxObj => patcher.remove(maxObj));
-  // }
-  // return cleanup;
-
   (() => {
       maxObjList.forEach(maxObj => patcher.remove(maxObj));
   })();

--- a/src/util_organization.js
+++ b/src/util_organization.js
@@ -1,25 +1,36 @@
 const getCleanupHandler = () => {
-  const maxObjList = getMaxObjList();
+  const lastObj = getLastMaxObj();
+  const maxObjList = getMaxObjList(lastObj);
+
   const cleanup = () => {
     maxObjList.forEach(maxObj => patcher.remove(maxObj));
   }
-
   return cleanup;
 };
 
 const alignCables = () => post("TODO alignCables");
 
-function getMaxObjList () {
+function getMaxObjList (firstObj) {
   const maxObjList = [];
-  let maxObj = patcher.firstobject;
+  let maxObj = firstObj;
   
-  while (maxObj) {
-    maxObjList.push(maxObj);
+  while (maxObj.nextobject) {
     maxObj = maxObj.nextobject;
+    maxObjList.push(maxObj);
   }
 
   return maxObjList;
 };
+
+function getLastMaxObj () {
+  let currentObj = patcher.firstobject;
+
+  while (currentObj.nextobject) {
+    currentObj = currentObj.nextobject;
+  }
+
+  return currentObj;
+}
 
 exports.getCleanupHandler = getCleanupHandler;
 exports.alignCables = alignCables;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@ const {
 } = require('utils_creation');
 
 const {
-  getCleanupHandler,
+  cleanup,
   alignCables
 } = require('util_organization');
 
@@ -14,5 +14,5 @@ const {positionMaxObjects} = require('util_box.js');
 exports.createMaxObject = createMaxObject;
 exports.createMaxObjects = createMaxObjects;
 exports.connect = connect;
-exports.getCleanupHandler = getCleanupHandler;
+exports.cleanup = cleanup;
 exports.positionMaxObjects = positionMaxObjects;

--- a/templates/starter.js
+++ b/templates/starter.js
@@ -7,13 +7,12 @@ const {
   createMaxObject,
   createMaxObjects,
   connect,
-  getCleanupHandler,
+  cleanup,
   positionMaxObjects,
 } = require('utils');
 
 const constructPatch = () => {
   const ARGS = getArgs();
-  const cleanup = getCleanupHandler();
   cleanup();
   const maxObjects = generateObjects();
 

--- a/templates/starter.js
+++ b/templates/starter.js
@@ -14,6 +14,7 @@ const {
 const constructPatch = () => {
   const ARGS = getArgs();
   const cleanup = getCleanupHandler();
+  cleanup();
   const maxObjects = generateObjects();
 
   connectMaxObjects(maxObjects);
@@ -23,7 +24,7 @@ const constructPatch = () => {
     posOffset: 100,
     boxOffset: 80
   });
-  cleanup();
+  
 
   function generateObjects () {
     const maxObjects = {
@@ -36,4 +37,3 @@ const constructPatch = () => {
     const {} = maxObjects;
   }
 };
-


### PR DESCRIPTION
feature/modify-cleanup
- Currently, cleanup deletes all maxobj's that exist in the patch prior to invoking `generateObjects`.  Desired behaviour should be deleting the objects that were created after invoking `generateObjects`.